### PR TITLE
Add lane cove scraper

### DIFF
--- a/infocouncil_scraper.py
+++ b/infocouncil_scraper.py
@@ -1,0 +1,43 @@
+import urllib.parse
+
+from base_scraper import BaseScraper, register_scraper
+from _dataclasses import ScraperReturn
+from bs4 import BeautifulSoup
+
+
+class InfoCouncilScraper(BaseScraper):
+    def __init__(self, council, state, base_url, infocouncil_url):
+        self.infocouncil_url = infocouncil_url
+        super().__init__(council, state, base_url)
+
+    def scraper(self) -> ScraperReturn | None:
+        self.logger.info(f"Starting {self.council_name} scraper")
+        output = self.fetch_with_requests(self.infocouncil_url )
+        soup = BeautifulSoup(output.content, "html.parser")
+        meeting_table = soup.find("table", id="grdMenu", recursive=True)
+        if meeting_table is None:
+            self.logger.info(f"{self.council_name} scraper found no meetings")
+            scraper_return = ScraperReturn(
+                name=None, date=None, time=None, webpage_url=None, download_url=None
+            )
+            return scraper_return
+        current_meeting = meeting_table.find("tbody").find_all("tr")[0]
+
+        relative_pdf_url = current_meeting.find(
+            "a", class_="bpsGridPDFLink", recursive=True
+        ).attrs["href"]
+        date_element = current_meeting.find("td", class_="bpsGridDate")
+        if date_element.span is not None:
+            time = date_element.span.text
+        else:
+            time = ""
+        scraper_return = ScraperReturn(
+            name=current_meeting.find("td", class_="bpsGridCommittee").text,
+            date=date_element.contents[0],
+            time=time,
+            webpage_url=self.infocouncil_url ,
+            download_url=urllib.parse.urljoin(self.infocouncil_url, relative_pdf_url),
+        )
+
+        self.logger.info(f"{self.council_name} scraper finished successfully")
+        return scraper_return

--- a/scrapers/nsw/bayside_nsw.py
+++ b/scrapers/nsw/bayside_nsw.py
@@ -5,47 +5,18 @@ parent_dir = str(Path(__file__).resolve().parent.parent.parent)
 if parent_dir not in sys.path:
     sys.path.append(parent_dir)
 
-from base_scraper import BaseScraper, register_scraper
-from logging.config import dictConfig
-from _dataclasses import ScraperReturn
-from bs4 import BeautifulSoup
+from base_scraper import register_scraper
+from infocouncil_scraper import InfoCouncilScraper
 
 
 @register_scraper
-class BaysideNSWScraper(BaseScraper):
+class BaysideNSWScraper(InfoCouncilScraper):
     def __init__(self):
-        council = "bayside_nsw"
-        state = "nsw"
-        base_url = "https://baysdie.nsw.gov.au"
-        super().__init__(council, state, base_url)
-
-    def scraper(self) -> ScraperReturn | None:
-        self.logger.info(f"Starting {self.council_name} scraper")
-        url = "https://infoweb.bayside.nsw.gov.au/?committee=1"
-        output = self.fetch_with_requests(url)
-        soup = BeautifulSoup(output.content, "html.parser")
-        meeting_table = soup.find("table", id="grdMenu", recursive=True)
-        if meeting_table is None:
-            self.logger.info(f"{self.council_name} scraper found no meetings")
-            scraper_return = ScraperReturn(
-                name=None, date=None, time=None, webpage_url=None, download_url=None
-            )
-            return scraper_return
-        current_meeting = meeting_table.find("tbody").find_all("tr")[0]
-
-        relative_pdf_url = current_meeting.find(
-            "a", class_="bpsGridPDFLink", recursive=True
-        ).attrs["href"]
-        scraper_return = ScraperReturn(
-            name=current_meeting.find("td", class_="bpsGridCommittee").text,
-            date=current_meeting.find("td", class_="bpsGridDate").text,
-            time="",
-            webpage_url=url,
-            download_url=f"{url}/{relative_pdf_url}",
-        )
-
-        self.logger.info(f"{self.council_name} scraper finished successfully")
-        return scraper_return
+        council = "bayside"
+        state = "NSW"
+        base_url = "https://bayside.nsw.gov.au"
+        infocouncil_url = "https://infoweb.bayside.nsw.gov.au/?committee=1"
+        super().__init__(council, state, base_url, infocouncil_url)
 
 
 if __name__ == "__main__":

--- a/scrapers/nsw/innerwest.py
+++ b/scrapers/nsw/innerwest.py
@@ -5,72 +5,18 @@ parent_dir = str(Path(__file__).resolve().parent.parent.parent)
 if parent_dir not in sys.path:
     sys.path.append(parent_dir)
 
-from base_scraper import BaseScraper, register_scraper
-from logging.config import dictConfig
-from _dataclasses import ScraperReturn
-from bs4 import BeautifulSoup
-import re
+from base_scraper import register_scraper
+from infocouncil_scraper import InfoCouncilScraper
 
 
 @register_scraper
-class InnerWestScraper(BaseScraper):
-    BUSINESS_PAPER_ROW_SELECTOR = "#grdMenu tbody > tr"
-    date_re = re.compile(
-        r"\b(\d{1,2})\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(\d{4})"
-    )
-    time_re = re.compile(r"\b(\d{1,2}:\d{2})(am|pm)\b")
-
+class InnerWestScraper(InfoCouncilScraper):
     def __init__(self):
         council = "inner_west"
         state = "NSW"
         base_url = "https://innerwest.infocouncil.biz"
-        super().__init__( council, state, base_url)
-
-    def scraper(self) -> ScraperReturn | None:
-        self.logger.info(f"Starting {self.council_name} scraper")
-        webpage_url = "https://innerwest.infocouncil.biz/papersonly.htm"
-
-        output = self.fetch_with_selenium(webpage_url)
-        soup = BeautifulSoup(output, "html.parser")
-        first_row = soup.select_one(self.BUSINESS_PAPER_ROW_SELECTOR)
-        if not first_row:
-            self.logger.error("No Business paper rows found")
-            return ScraperReturn("", "", "", self.base_url, "")
-        else:
-            name = first_row.select_one(".bpsGridCommittee").text.strip()
-
-            date_match = self.date_re.search(first_row.text)
-            date = date_match.group(0) if date_match else ""
-
-            time_match = self.time_re.search(first_row.text)
-            time = time_match.group(0) if time_match else ""
-
-            pdf_link_element = first_row.select_one("a.bpsGridPDFLink")
-            pdf_url = (
-                pdf_link_element["href"] if pdf_link_element else "PDF link not found"
-            )
-            download_url = (
-                f"{self.base_url}/{pdf_url}"
-                if pdf_url != "PDF link not found"
-                else pdf_url
-            )
-            self.logger.info(
-                f"Scraped: {name}, Date: {date}, Time: {time}, PDF URL: {download_url}"
-            )
-            scraper_return = ScraperReturn(
-                name, date, time, self.base_url, download_url
-            )
-            self.logger.info(f"{self.council_name} scraper finished successfully")
-
-        self.logger.info(
-            f"""
-            {scraper_return.name} 
-            {scraper_return.date} 
-            {scraper_return.time} 
-            {scraper_return.webpage_url} 
-            {scraper_return.download_url}"""
-        )
-        return scraper_return
+        infocouncil_url = "https://innerwest.infocouncil.biz/Default.aspx"
+        super().__init__(council, state, base_url, infocouncil_url)
 
 
 if __name__ == "__main__":

--- a/scrapers/nsw/lane_cove.py
+++ b/scrapers/nsw/lane_cove.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+parent_dir = str(Path(__file__).resolve().parent.parent.parent)
+if parent_dir not in sys.path:
+    sys.path.append(parent_dir)
+
+from infocouncil_scraper import InfoCouncilScraper
+from base_scraper import register_scraper
+
+
+@register_scraper
+class LaneCoveScraper(InfoCouncilScraper):
+    def __init__(self):
+        council = "lane_cove"
+        state = "NSW"
+        base_url = "https://lanecove.infocouncil.biz"
+        infocouncil_url = "https://lanecove.infocouncil.biz"
+        super().__init__(council, state, base_url, infocouncil_url)
+
+
+if __name__ == "__main__":
+    scraper = LaneCoveScraper()
+    scraper.scraper()

--- a/scrapers/nsw/parramatta.py
+++ b/scrapers/nsw/parramatta.py
@@ -5,71 +5,18 @@ parent_dir = str(Path(__file__).resolve().parent.parent.parent)
 if parent_dir not in sys.path:
     sys.path.append(parent_dir)
 
-from base_scraper import BaseScraper, register_scraper
-from logging.config import dictConfig
-from _dataclasses import ScraperReturn
-from bs4 import BeautifulSoup
-import re
+from infocouncil_scraper import InfoCouncilScraper
+from base_scraper import register_scraper
 
 
 @register_scraper
-class ParramattaScraper(BaseScraper):
-    BUSINESS_PAPER_ROW_SELECTOR = "#grdMenu tbody > tr"
-    date_re = re.compile(
-        r"\b(\d{1,2})\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(\d{4})"
-    )
-    time_re = re.compile(r"\b(\d{1,2}:\d{2})(am|pm)\b")
-
+class ParramattaScraper(InfoCouncilScraper):
     def __init__(self):
         council = "parramatta"
-        state = "nsw"
+        state = "NSW"
         base_url = "https://businesspapers.parracity.nsw.gov.au"
-        super().__init__(council, state, base_url)
-
-    def scraper(self) -> ScraperReturn | None:
-        self.logger.info(f"Starting {self.council_name} scraper")
-        output = self.fetch_with_selenium(self.base_url)
-        self.close()
-        soup = BeautifulSoup(output, "html.parser")
-        first_row = soup.select_one(self.BUSINESS_PAPER_ROW_SELECTOR)
-        if not first_row:
-            self.logger.error("No Business paper rows found")
-            return ScraperReturn("", "", "", self.base_url, "")
-        else:
-            name = first_row.select_one(".bpsGridCommittee").text.strip()
-
-            date_match = self.date_re.search(first_row.text)
-            date = date_match.group(0) if date_match else ""
-
-            time_match = self.time_re.search(first_row.text)
-            time = time_match.group(0) if time_match else ""
-
-            pdf_link_element = first_row.select_one("a.bpsGridPDFLink")
-            pdf_url = (
-                pdf_link_element["href"] if pdf_link_element else "PDF link not found"
-            )
-            download_url = (
-                f"{self.base_url}/{pdf_url}"
-                if pdf_url != "PDF link not found"
-                else pdf_url
-            )
-            self.logger.info(
-                f"Scraped: {name}, Date: {date}, Time: {time}, PDF URL: {download_url}"
-            )
-            scraper_return = ScraperReturn(
-                name, date, time, self.base_url, download_url
-            )
-            self.logger.info(f"{self.council_name} scraper finished successfully")
-
-        self.logger.info(
-            f"""
-            {scraper_return.name} 
-            {scraper_return.date} 
-            {scraper_return.time} 
-            {scraper_return.webpage_url} 
-            {scraper_return.download_url}"""
-        )
-        return scraper_return
+        infocouncil_url = "https://businesspapers.parracity.nsw.gov.au"
+        super().__init__(council, state, base_url, infocouncil_url)
 
 
 if __name__ == "__main__":

--- a/scrapers/vic/port_phillip.py
+++ b/scrapers/vic/port_phillip.py
@@ -5,83 +5,17 @@ parent_dir = str(Path(__file__).resolve().parent.parent.parent)
 if parent_dir not in sys.path:
     sys.path.append(parent_dir)
 
-from base_scraper import BaseScraper, register_scraper
-from logging.config import dictConfig
-from _dataclasses import ScraperReturn
-from bs4 import BeautifulSoup
-import re
-
+from infocouncil_scraper import InfoCouncilScraper
+from base_scraper import register_scraper
 
 @register_scraper
-class PortPhilipScraper(BaseScraper):
+class PortPhilipScraper(InfoCouncilScraper):
     def __init__(self):
         council = "port_philip"
         state = "VIC"
         base_url = "https://www.portphillip.vic.gov.au/"
-        super().__init__(council, state, base_url)
-        self.date_pattern = (
-            r"\b(\d{1,2})\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(\d{4})\b"
-        )
-        self.time_pattern = r"\b(\d{1,2}:\d{2})\s(AM|PM)\b"
-
-    def scraper(self) -> ScraperReturn | None:
-        webpage_url = "https://portphillip.infocouncil.biz/"
-        output = self.fetch_with_selenium(webpage_url)
-        self.close()
-
-        # Feed HTML to BeautifulSoup
-        soup = BeautifulSoup(output, "html.parser")
-
-        name = None
-        date = None
-        time = None
-        download_url = None
-
-        td_name = soup.find("td", class_="bpsGridCommittee")
-        if td_name:
-            name = td_name.get_text()
-            name = name.rstrip("St Kilda Town Hall")
-        else:
-            print("td_name not found")
-
-        td_date_time = soup.find("td", class_="bpsGridDate")
-        if td_date_time:
-            date_time = td_date_time.get_text()
-            # splits council-provided "dd mm yytime" into "dd mm yy" + "time"
-            split_dt = re.split(r"\s", date_time)
-            day = split_dt[0]
-            month = split_dt[1]
-            year = split_dt[2][:4]
-            time = split_dt[2][4:]
-            date = day + " " + month + " " + year
-        else:
-            print("td_date_time not found")
-
-        td_download_url = soup.find("td", class_="bpsGridAgenda")
-        if td_download_url:
-            download_url_line = soup.find("a", class_="bpsGridPDFLink")
-            if download_url_line:
-                link = download_url_line.get("href")
-                if link:
-                    download_url = webpage_url + link
-                else:
-                    print("link not found")
-            else:
-                print("download_url_line not found")
-        else:
-            print("td_download_url not found")
-
-        scraper_return = ScraperReturn(name, date, time, webpage_url, download_url)
-
-        print(
-            scraper_return.name,
-            scraper_return.date,
-            scraper_return.time,
-            scraper_return.webpage_url,
-            scraper_return.download_url,
-        )
-
-        return scraper_return
+        infocouncil_url = "https://portphillip.infocouncil.biz/"
+        super().__init__(council, state, base_url, infocouncil_url)
 
 
 if __name__ == "__main__":

--- a/scrapers/vic/whitehorse.py
+++ b/scrapers/vic/whitehorse.py
@@ -5,73 +5,18 @@ parent_dir = str(Path(__file__).resolve().parent.parent.parent)
 if parent_dir not in sys.path:
     sys.path.append(parent_dir)
 
-from base_scraper import BaseScraper, register_scraper
-from logging.config import dictConfig
-from _dataclasses import ScraperReturn
-from bs4 import BeautifulSoup
-import re
+from base_scraper import register_scraper
+from infocouncil_scraper import InfoCouncilScraper
 
 
 @register_scraper
-class WhitehorseScraper(BaseScraper):
+class WhitehorseScraper(InfoCouncilScraper):
     def __init__(self):
         council = "whitehorse"
         state = "VIC"
         base_url = "https://www.whitehorse.vic.gov.au/"
-        super().__init__(council, state, base_url)
-
-    def scraper(self) -> ScraperReturn | None:
-        webpage_url = "https://whitehorse.infocouncil.biz/"
-
-        output = self.fetch_with_selenium(webpage_url)
-        self.close()
-
-        # Feed HTML to BeautifulSoup
-        soup = BeautifulSoup(output, "html.parser")
-
-        name = None
-        date = None
-        time = None
-        download_url = None
-
-        td_name = soup.find("td", class_="bpsGridCommittee")
-        if td_name:
-            name = td_name.get_text()
-        else:
-            print("td_name not found")
-
-        td_date = soup.find("td", class_="bpsGridDate")
-        if td_date:
-            date = td_date.get_text()
-        else:
-            print("td_date not found")
-
-        # gets download url
-        td_download_url = soup.find("td", class_="bpsGridAgenda")
-        if td_download_url:
-            download_url_line = soup.find("a", class_="bpsGridPDFLink")
-            if download_url_line:
-                link = download_url_line.get("href")
-                if link:
-                    download_url = webpage_url + link
-                else:
-                    print("link not found")
-            else:
-                print("download_url_line not found")
-        else:
-            print("td_download_url not found")
-
-        scraper_return = ScraperReturn(name, date, time, webpage_url, download_url)
-
-        print(
-            scraper_return.name,
-            scraper_return.date,
-            scraper_return.time,
-            scraper_return.webpage_url,
-            scraper_return.download_url,
-        )
-
-        return scraper_return
+        infocouncil_url = "https://whitehorse.infocouncil.biz/"
+        super().__init__(council, state, base_url, infocouncil_url)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add the Lane Cove scraper.

This PR is branched off of #27 since this is also an Infocouncil scraper – sorry I'm not familiar with a good way to stack PRs cross-fork on Github, but you should merge that first.

Tested locally, ended up with this entry in agendas.db which looks right as far as I can tell

```
sqlite> select * from agendas where council="lane_cove";
10|2024-02-05|lane_cove|20 Dec 2023||https://lanecove.infocouncil.biz|https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2023/12/LPP_20122023_AGN.PDF|{"keyword_matches": {"dwellings": 6, "heritage": 12}}|
```