### PR TITLE
FIX: Yarra council name

### DIFF
--- a/council_scrapers/scrapers/vic/yarra.py
+++ b/council_scrapers/scrapers/vic/yarra.py
@@ -6,7 +6,7 @@ import re
 @register_scraper
 class YarraScraper(BaseScraper):
     def __init__(self):
-        council = "bayside_vic"
+        council = "yarra"
         state = "VIC"
         base_url = "https://www.yarracity.vic.gov.au"
         super().__init__(council, state, base_url)


### PR DESCRIPTION
Pretty sure this shouldn't be bayside_vic especially with it as the model scraper in the README (: