### PR TITLE
Merge InfoCouncil meetings split across two listing rows

### DIFF
--- a/aus_council_scrapers/base.py
+++ b/aus_council_scrapers/base.py
@@ -446,6 +446,53 @@ class BaseScraper(ABC):
         raise NotImplementedError("Scrape method must be implemented by the subclass.")
 
 
+_DOCUMENT_FIELDS = ("agenda_url", "minutes_url", "agenda_html_url", "minutes_html_url")
+
+
+def _merge_split_meetings(results: list[ScraperReturn]) -> list[ScraperReturn]:
+    """Combine rows that are one meeting split across separate listings.
+
+    Some InfoCouncil sites emit two `div.meeting-row` entries for a single
+    meeting — one carrying the agenda, another the minutes. Left alone that
+    produces two records for one meeting, each missing half its documents,
+    which defeats the point of holding agenda and minutes together.
+
+    Only complementary rows are merged. Two rows sharing a name and date but
+    each holding a *different* agenda are two real meetings — a council can
+    hold two special meetings on one night — so any conflicting field blocks
+    the merge and both records survive.
+    """
+    merged: list[ScraperReturn] = []
+    by_identity: dict[tuple, ScraperReturn] = {}
+
+    for record in results:
+        key = (record.name, record.date)
+        existing = by_identity.get(key)
+
+        if existing is None or any(
+            getattr(existing, field)
+            and getattr(record, field)
+            and getattr(existing, field) != getattr(record, field)
+            for field in _DOCUMENT_FIELDS
+        ):
+            by_identity.setdefault(key, record)
+            merged.append(record)
+            continue
+
+        for field in _DOCUMENT_FIELDS:
+            if not getattr(existing, field):
+                setattr(existing, field, getattr(record, field))
+        for field in ("time", "location"):
+            if not getattr(existing, field):
+                setattr(existing, field, getattr(record, field))
+        # download_url is deprecated but still consumed: keep it pointing at
+        # the agenda now that one is known.
+        if not existing.download_url:
+            existing.download_url = existing.agenda_url or existing.minutes_url
+
+    return merged
+
+
 class InfoCouncilScraper(BaseScraper):
     def __init__(self, council, state, base_url, infocouncil_url):
         self.infocouncil_url = infocouncil_url
@@ -666,7 +713,7 @@ class InfoCouncilScraper(BaseScraper):
                 )
             )
 
-        return results
+        return _merge_split_meetings(results)
 
     @staticmethod
     def _responsive_text(row, class_name: str) -> str:

--- a/tests/test-cases/lane_cove-result.json
+++ b/tests/test-cases/lane_cove-result.json
@@ -401,23 +401,11 @@
     "time": "7pm",
     "location": "Council Chambers",
     "webpage_url": "https://lanecove.infocouncil.biz",
-    "download_url": null,
-    "agenda_url": null,
-    "minutes_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/12/CNL_08122022_MIN.PDF",
-    "agenda_html_url": null,
-    "minutes_html_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/12/CNL_08122022_MIN_WEB.htm"
-  },
-  {
-    "name": "Ordinary Council",
-    "date": "08 Dec 2022",
-    "time": "7pm",
-    "location": "Council Chambers",
-    "webpage_url": "https://lanecove.infocouncil.biz",
     "download_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/12/CNL_08122022_AGN_AT.PDF",
     "agenda_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/12/CNL_08122022_AGN_AT.PDF",
-    "minutes_url": null,
+    "minutes_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/12/CNL_08122022_MIN.PDF",
     "agenda_html_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/12/CNL_08122022_AGN_AT_WEB.htm",
-    "minutes_html_url": null
+    "minutes_html_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/12/CNL_08122022_MIN_WEB.htm"
   },
   {
     "name": "Lane Cove Local Planning Panel",
@@ -437,23 +425,11 @@
     "time": "7pm",
     "location": "Council Chambers",
     "webpage_url": "https://lanecove.infocouncil.biz",
-    "download_url": null,
-    "agenda_url": null,
-    "minutes_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/11/CNL_24112022_MIN.PDF",
-    "agenda_html_url": null,
-    "minutes_html_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/11/CNL_24112022_MIN_WEB.htm"
-  },
-  {
-    "name": "Ordinary Council",
-    "date": "24 Nov 2022",
-    "time": "7pm",
-    "location": "Council Chambers",
-    "webpage_url": "https://lanecove.infocouncil.biz",
     "download_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/11/CNL_24112022_AGN_AT.PDF",
     "agenda_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/11/CNL_24112022_AGN_AT.PDF",
-    "minutes_url": null,
+    "minutes_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/11/CNL_24112022_MIN.PDF",
     "agenda_html_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/11/CNL_24112022_AGN_AT_WEB.htm",
-    "minutes_html_url": null
+    "minutes_html_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/11/CNL_24112022_MIN_WEB.htm"
   },
   {
     "name": "Lane Cove Local Planning Panel",
@@ -485,23 +461,11 @@
     "time": "7:00 PM",
     "location": "Council Chambers",
     "webpage_url": "https://lanecove.infocouncil.biz",
-    "download_url": null,
-    "agenda_url": null,
-    "minutes_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/10/CNL_27102022_MIN.PDF",
-    "agenda_html_url": null,
-    "minutes_html_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/10/CNL_27102022_MIN_WEB.htm"
-  },
-  {
-    "name": "Ordinary Council",
-    "date": "27 Oct 2022",
-    "time": "7:00 PM",
-    "location": "Council Chambers",
-    "webpage_url": "https://lanecove.infocouncil.biz",
     "download_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/10/CNL_27102022_AGN_AT.PDF",
     "agenda_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/10/CNL_27102022_AGN_AT.PDF",
-    "minutes_url": null,
+    "minutes_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/10/CNL_27102022_MIN.PDF",
     "agenda_html_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/10/CNL_27102022_AGN_AT_WEB.htm",
-    "minutes_html_url": null
+    "minutes_html_url": "https://lanecove.infocouncil.biz/RedirectToDoc.aspx?URL=Open/2022/10/CNL_27102022_MIN_WEB.htm"
   },
   {
     "name": "Ordinary Council",

--- a/tests/test_merge_split_meetings.py
+++ b/tests/test_merge_split_meetings.py
@@ -1,0 +1,100 @@
+"""Tests for merging a meeting split across two listing rows.
+
+Some InfoCouncil sites list one meeting twice — once with its agenda, once
+with its minutes. Merging them is only safe when the two rows do not
+disagree, so the boundary matters more than the happy path.
+"""
+
+from aus_council_scrapers.base import ScraperReturn, _merge_split_meetings
+
+
+def _meeting(**overrides):
+    fields = dict(
+        name="Ordinary Council",
+        date="08 Dec 2022",
+        time=None,
+        webpage_url="https://example.infocouncil.biz/",
+    )
+    fields.update(overrides)
+    return ScraperReturn(**fields)
+
+
+def test_agenda_row_and_minutes_row_become_one_meeting():
+    merged = _merge_split_meetings(
+        [
+            _meeting(minutes_url="https://x.test/MIN.PDF"),
+            _meeting(agenda_url="https://x.test/AGN.PDF"),
+        ]
+    )
+    assert len(merged) == 1
+    assert merged[0].agenda_url == "https://x.test/AGN.PDF"
+    assert merged[0].minutes_url == "https://x.test/MIN.PDF"
+
+
+def test_merging_fills_in_the_deprecated_download_url():
+    merged = _merge_split_meetings(
+        [
+            _meeting(minutes_url="https://x.test/MIN.PDF"),
+            _meeting(agenda_url="https://x.test/AGN.PDF"),
+        ]
+    )
+    assert merged[0].download_url == "https://x.test/AGN.PDF"
+
+
+def test_two_real_meetings_on_one_night_are_not_merged():
+    """A council can hold two special meetings the same evening. Each has its
+    own agenda, so the rows conflict and both must survive."""
+    merged = _merge_split_meetings(
+        [
+            _meeting(name="Special Council", agenda_url="https://x.test/A1.PDF"),
+            _meeting(name="Special Council", agenda_url="https://x.test/A2.PDF"),
+        ]
+    )
+    assert len(merged) == 2
+
+
+def test_different_dates_are_never_merged():
+    merged = _merge_split_meetings(
+        [
+            _meeting(date="08 Dec 2022", agenda_url="https://x.test/A.PDF"),
+            _meeting(date="24 Nov 2022", minutes_url="https://x.test/M.PDF"),
+        ]
+    )
+    assert len(merged) == 2
+
+
+def test_html_variants_merge_too():
+    merged = _merge_split_meetings(
+        [
+            _meeting(minutes_url="https://x.test/M.PDF", minutes_html_url="https://x.test/M.htm"),
+            _meeting(agenda_url="https://x.test/A.PDF", agenda_html_url="https://x.test/A.htm"),
+        ]
+    )
+    assert len(merged) == 1
+    assert merged[0].agenda_html_url == "https://x.test/A.htm"
+    assert merged[0].minutes_html_url == "https://x.test/M.htm"
+
+
+def test_time_and_location_are_taken_from_whichever_row_has_them():
+    merged = _merge_split_meetings(
+        [
+            _meeting(minutes_url="https://x.test/M.PDF"),
+            _meeting(
+                agenda_url="https://x.test/A.PDF",
+                time="7:00 PM",
+                location="Council Chambers",
+            ),
+        ]
+    )
+    assert merged[0].time == "7:00 PM"
+    assert merged[0].location == "Council Chambers"
+
+
+def test_ordering_is_preserved():
+    merged = _merge_split_meetings(
+        [
+            _meeting(date="08 Dec 2022", agenda_url="https://x.test/A.PDF"),
+            _meeting(date="24 Nov 2022", agenda_url="https://x.test/B.PDF"),
+        ]
+    )
+    assert [m.date for m in merged] == ["08 Dec 2022", "24 Nov 2022"]


### PR DESCRIPTION
## Why

Lane Cove showed as 🟡 partial in `docs/status.md` despite the InfoCouncil template fix working well — 164 meetings across 2020-2026 with minutes. The single reason was three meetings recorded twice.

They are not duplicates. The redesigned InfoCouncil listing emits **two `div.meeting-row` entries for the same meeting** — one carrying the agenda, the other the minutes:

```
row 0: date='08 Dec 2022' title='Ordinary Council'   group: 'Minutes'
row 1: date='08 Dec 2022' title='Ordinary Council'   group: 'Agenda'
                                                     group: 'Agenda - Supplementary'
```

So the scraper produced two records for one meeting, each holding half its documents — which defeats the point of carrying agenda and minutes on the same record. Affected `08 Dec 2022`, `24 Nov 2022` and `27 Oct 2022`.

## What changed

`_merge_split_meetings()` combines rows sharing a name and date, applied at the end of `_scrape_responsive_rows`.

The important part is what it refuses to merge. Two rows sharing a name and date but each holding a **different** agenda are two genuinely different meetings — a council can hold two special meetings on one night, and Glen Eira does exactly that (7:15pm and 7:30pm on 26 October 2021). So any conflicting document field blocks the merge and both records survive. Only complementary rows combine.

`time` and `location` are taken from whichever row has them, and the deprecated `download_url` is repointed at the agenda once one is known.

## Result

`lane_cove`: **164 → 161 meetings**, and it moves from 🟡 partial to ✅ **complete**. Coverage overall goes 16/60 → **17/60**.

No other council was affected — `python scripts/scorecard.py` reports no remaining split agenda/minutes rows.

The expected result was regenerated from the **existing cassette** rather than re-recorded live, so the diff shows only the effect of the merge and not unrelated meetings published since the cassette was cut.

## Tests

`tests/test_merge_split_meetings.py` covers the boundary rather than just the happy path: complementary rows merge, two real meetings on one night do not, different dates never merge, HTML variants merge, time/location are filled from whichever row has them, and ordering is preserved.

Full suite: **131 passed, 1 skipped, 5 xfailed.**

## Noticed but not fixed

Randwick has a different bug in the **legacy** grid parser: for `Ordinary Council / 30 Jun 2026`, one row's `agenda_url` points at a minutes PDF (`OC_30062026_MIN_4126_AT.PDF`). It does not trip the split-rows rule because that row carries both fields, so Randwick still reports `complete` — but some of its 431 "agendas" are actually minutes files. That is in the legacy path, would touch every legacy InfoCouncil council, and needs its own change. Happy to raise an issue for it.
